### PR TITLE
[FIX] IndexError when parsing incomplete urls without a host part

### DIFF
--- a/src/mdurl/_parse.py
+++ b/src/mdurl/_parse.py
@@ -202,7 +202,7 @@ class MutableURL:
             if host_end == -1:
                 host_end = len(rest)
 
-            if rest[host_end - 1] == ":":
+            if host_end > 0 and rest[host_end - 1] == ":":
                 host_end -= 1
             host = rest[:host_end]
             rest = rest[host_end:]

--- a/tests/fixtures/url.py
+++ b/tests/fixtures/url.py
@@ -601,4 +601,11 @@ PARSED = {
         "pathname": "/fooA100%mBr",
         "slashes": True,
     },
+    #
+    "http://": {
+        "protocol": "http:",
+        "hostname": "",
+        "pathname": "",
+        "slashes": True,
+    }
 }

--- a/tests/fixtures/url.py
+++ b/tests/fixtures/url.py
@@ -605,7 +605,6 @@ PARSED = {
     "http://": {
         "protocol": "http:",
         "hostname": "",
-        "pathname": "",
         "slashes": True,
     }
 }


### PR DESCRIPTION
When parsing an incomplete url without host like "http://" a IndexError will be thrown. In contrast to this the upstream javascript version returns an almost empty parse result:

`url {protocol: 'http:', slashes: true, auth: null, port: null, hostname: '', pathname: null, search: null, hash: null}`

The IndexError occurs in Python on accessing an array with a negative index. In contrast, in javascript a negative index results in the value "undefined".

See also https://github.com/executablebooks/markdown-it-py/issues/205